### PR TITLE
ADD: ability to pull items from nested properties

### DIFF
--- a/includes/editor.php
+++ b/includes/editor.php
@@ -46,17 +46,10 @@ class Editor extends \Jet_Engine\Query_Builder\Query_Editor\Base_Query {
 				/>
 				<cx-vui-input
 					label="<?php _e( 'Parent Object Property', 'jet-engine' ); ?>"
-					description="<?php _e( 'Property name from prent listing item object to get data from.', 'jet-engine' ); ?>"
+					description="<?php _e( 'Property name from prent listing item object to get data from. For nested properties/array elements, you can specify full path as properties/keys names separated by `/`; for example: `object_property/child_property`.', 'jet-engine' ); ?>"
 					:wrapper-css="[ 'equalwidth', 'has-macros' ]"
 					size="fullwidth"
 					v-model="query.prop"
-				><jet-query-dynamic-args v-model="dynamicQuery.prop"></jet-query-dynamic-args></cx-vui-input>
-				<cx-vui-input
-					label="<?php _e( 'Items path', 'jet-engine' ); ?>"
-					description="<?php _e( 'If items are nested in property, set the path to the items separated with `/` for example: `/data/items`. Otherwise, leave this field blank.', 'jet-engine' ); ?>"
-					:wrapper-css="[ 'equalwidth', 'has-macros' ]"
-					size="fullwidth"
-					v-model="query.items_path"
 				><jet-query-dynamic-args v-model="dynamicQuery.prop"></jet-query-dynamic-args></cx-vui-input>
 				<cx-vui-component-wrapper
 					:wrapper-css="[ 'fullwidth-control' ]"

--- a/includes/editor.php
+++ b/includes/editor.php
@@ -51,6 +51,13 @@ class Editor extends \Jet_Engine\Query_Builder\Query_Editor\Base_Query {
 					size="fullwidth"
 					v-model="query.prop"
 				><jet-query-dynamic-args v-model="dynamicQuery.prop"></jet-query-dynamic-args></cx-vui-input>
+				<cx-vui-input
+					label="<?php _e( 'Items path', 'jet-engine' ); ?>"
+					description="<?php _e( 'If items are nested in property, set the path to the items separated with `/` for example: `/data/items`. Otherwise, leave this field blank.', 'jet-engine' ); ?>"
+					:wrapper-css="[ 'equalwidth', 'has-macros' ]"
+					size="fullwidth"
+					v-model="query.items_path"
+				><jet-query-dynamic-args v-model="dynamicQuery.prop"></jet-query-dynamic-args></cx-vui-input>
 				<cx-vui-component-wrapper
 					:wrapper-css="[ 'fullwidth-control' ]"
 				>

--- a/includes/query.php
+++ b/includes/query.php
@@ -23,14 +23,24 @@ class Query extends \Jet_Engine\Query_Builder\Queries\Base_Query {
 
 		$current_object = jet_engine()->listings->data->get_current_object();
 
+		$prop = trim( $prop, '/' );
+
+		if ( strpos( $prop , '/' ) ) {
+			$path_array = explode( '/', $prop );
+			$prop       = array_shift( $path_array );
+			$path       = implode( '/' , $path_array );
+		}
+
 		if ( ! $current_object || ! isset( $current_object->$prop ) ) {
 			return $result;
 		}
 
-		$path = $this->final_query['items_path'] ?? false;
-
 		if ( $path ) {
 			$result = jet_engine_get_child( $current_object->$prop ?? array(), $path );
+		}
+
+		if ( is_object( $result ) ) {
+			$result = ( array ) $result;
 		}
 
 		if ( ! is_array( $result ) ) {

--- a/includes/query.php
+++ b/includes/query.php
@@ -23,11 +23,19 @@ class Query extends \Jet_Engine\Query_Builder\Queries\Base_Query {
 
 		$current_object = jet_engine()->listings->data->get_current_object();
 
-		if ( ! $current_object || ! isset( $current_object->$prop ) || ! is_array( $current_object->$prop ) ) {
+		if ( ! $current_object || ! isset( $current_object->$prop ) ) {
 			return $result;
 		}
 
-		$result = $current_object->$prop;
+		$path = $this->final_query['items_path'] ?? false;
+
+		if ( $path ) {
+			$result = jet_engine_get_child( $current_object->$prop ?? array(), $path );
+		}
+
+		if ( ! is_array( $result ) ) {
+			return array();
+		}
 
 		array_walk( $result, function( &$item, $index ) {
 


### PR DESCRIPTION
У чувака вот такие айтемы примерно

```
[0] => stdClass Object
        (
            [PropertyFeatures] => stdClass Object
                (
                    [Category] => Array
                        (
                            [0] => stdClass Object
                                (
                                    [Type] => Setting
                                    [Value] => Array
                                        (
                                            [0] => cat1
                                            [1] => cat2
                                        )

                                )

                            [1] => stdClass Object
                                (
                                    [Type] => Orientation
                                    [Value] => Array
                                        (
                                            [0] => West
                                        )

                                )

                        )

                )

        )
```

он хочет вытащить Value из Category; но так как Category лежит не непосредственно в объекте, а в PropertyFeatures, он этого сделать не может

Если добавить items_path https://prnt.sc/mYYZLTzt7wjV то можно будет вытаскивать такие штуки, в данном случае я потом в листинге по саб квери вот так могу вытащить эти категории https://prnt.sc/1k_jxHwxWmZG